### PR TITLE
Repeated lookup issue#6

### DIFF
--- a/SPAEML/src/main/scala/spaeml/SPAEML.scala
+++ b/SPAEML/src/main/scala/spaeml/SPAEML.scala
@@ -1,6 +1,7 @@
 package spaeml
   
 import statistics._
+
 import scala.collection.mutable
 import org.apache.spark._
 import org.apache.spark.sql._
@@ -16,9 +17,6 @@ import org.apache.spark.storage.StorageLevel
  *    where an X is included under high p-value, then skipped, then included again, ... and this goes on forever
  */
 
-case class StepCollections(not_added: mutable.HashSet[String],
-                           added_prev: mutable.HashSet[String] = mutable.HashSet(),
-                           skipped: mutable.HashSet[String] = mutable.HashSet())
 
 abstract class FileData(val sampleNames: Vector[String],
                         val dataPairs: Vector[(String, DenseVector[Double])]
@@ -37,7 +35,7 @@ trait SPAEML extends Serializable {
                            broadMap: Broadcast[Map[String, DenseVector[Double]]]
                           ): (String, DenseVector[Double])
   
-  /*
+  /**
    * 1. Broadcast the original SNP table throughout the cluster
    * 2. Create and distribute a Vector of columnName pairs for the SNP table
    * 3. On each Executor, create the SNP pairs for the columnName pairs on that Executor

--- a/SPAEML/src/main/scala/spaeml/SPAEMLDense.scala
+++ b/SPAEML/src/main/scala/spaeml/SPAEMLDense.scala
@@ -2,6 +2,7 @@ package spaeml
 
 import statistics._
 import scala.annotation.tailrec
+import scala.collection.mutable
 import org.apache.spark._
 import org.apache.spark.broadcast._
 import breeze.linalg.DenseVector
@@ -59,19 +60,19 @@ object SPAEMLDense extends SPAEML {
   @tailrec
   def performSteps(spark: SparkContext,
                    snpDataRDD: rdd.RDD[(String, DenseVector[Double])],
-                   broadcastPhenotypes: Broadcast[Map[String, DenseVector[Double]]],
-                   phenotypeName: String,
+                   broadcastPheno: Broadcast[Map[String, DenseVector[Double]]],
+                   phenoName: String,
                    collections: StepCollections,
                    threshold: Double,
                    prev_best_model: OLSRegression = null, // Initialized to null in super trait
-                   iterations: Int = 1// Initialized to 1 in super trait
+                   iterations: Int = 1 // Initialized to 1 in super trait
                   ): OLSRegression = {
-    
-    println("Iteration number: " + iterations.toString)    
+
+    println("Iteration number: " + iterations.toString)
     /*
      *  LOCAL FUNCTIONS
      */
-    
+
     /**
      * Returns the p-value associated with the newest term
      *
@@ -79,15 +80,12 @@ object SPAEMLDense extends SPAEML {
      *    as it assumes the last one is associated with the intercept
      */
     val getNewestTermsPValue = (reg: OLSRegression) => {
-      // Drop the estimate of the intercept and return the p-value of the most recently added term 
+      // Drop the estimate of the intercept and return the p-value of the most recently added term
       reg.pValues.toArray.dropRight(1).last
     }
 
-    /** Returns the name of the most recently added term */
     val getNewestTermsName = (reg: OLSRegression) => reg.xColumnNames.last
-
-    /** */
-    val getNewestTermsValues = (reg: OLSRegression) => reg.lastXColumnsValues()
+    val getNewestTermsValues = (reg: OLSRegression) => reg.lastXColumnsValues().toDenseVector
 
     /**
      * Returns a OLSRegression object if the inputSnp is in the NotAdded category
@@ -95,32 +93,33 @@ object SPAEMLDense extends SPAEML {
      *  Otherwise, an object of type None is returned (this SNP was not analyzed
      *    on this iteration)
      */
-    def mapFunction(inputSnp: (String, DenseVector[Double]),
-                    addedPrevBroadcast: Broadcast[Map[String, DenseVector[Double]]]
-                   ): Option[OLSRegressionDense] = {
-      
+    def mapFunction(inputSnp: (String, DenseVector[Double])): Option[OLSRegressionDense] = {
+
       // If the inputSnp is in the not_added category
       if ( collections.getNotAdded.contains(inputSnp._1) ) {
-        val yVals = broadcastPhenotypes.value(phenotypeName)
+        val yVals = broadcastPheno.value(phenoName)
         val xColNames = collections.getAddedPrev.toArray
-        
+
         val numRows = yVals.length
         val numCols = xColNames.length
-        
-        val xVals: Array[Double] = xColNames.flatMap(addedPrevBroadcast.value(_))
+
+        val xVals = xColNames.flatMap(collections.addedPrevValues(_))
 
         val newXColNames = xColNames :+ inputSnp._1
-        
+
         val newXVals: Array[Double] = xVals ++ inputSnp._2
         val newXValsAsMatrix = new DenseMatrix(numRows, numCols + 1, newXVals)
 
-        return Some(new OLSRegressionDense(newXColNames, phenotypeName, newXValsAsMatrix, yVals))
+        return Some(new OLSRegressionDense(newXColNames, phenoName, newXValsAsMatrix, yVals))
       } else {
         // Do not analyze this SNP
         return None
       }
     }
 
+    /**
+      * Return the best model (non-deterministic when there are ties; as the tie is broken arbitrarily
+      */
     def reduceFunction(inputRDD: rdd.RDD[Option[OLSRegression]]): OLSRegression = {
       val filtered = inputRDD.filter(x => x.isDefined).map(_.get)
       if (!filtered.isEmpty()) {
@@ -128,160 +127,93 @@ object SPAEMLDense extends SPAEML {
           if (getNewestTermsPValue(x) <= getNewestTermsPValue(y)) x else y
         })
       } else {
-        /* warning: if this occurs the broadcast variable will not have been explicitly destroyed
-         * Not certain spark automatically destroys it when it leaves scope, although that seems likely */
         // There are no more potential SNPs to be added
         throw new Exception("There are no more SNPs under consideration")
       }
     }
 
+    /**
+      *  Returns a new model built with the current entries in the collections.added_prev category
+      *  (because collections has mutable state, this can be used to recreate the model after a change to collections
+      *   has been made)
+      */
+    def rebuildModel(): OLSRegressionDense = {
+      val xNames: Array[String] = collections.getAddedPrev.toArray
+      val xVals: Array[Double] = xNames.flatMap(collections.addedPrevValues(_).toScalaVector())
+
+      val yVals = broadcastPheno.value(phenoName)
+
+      val numRows = yVals.length
+      val numCols = xNames.length
+
+      val xValsMatrix: DenseMatrix[Double] = new DenseMatrix(numRows, numCols, xVals)
+
+      new OLSRegressionDense(xNames, phenoName, xValsMatrix, yVals)
+    }
     /*
      * IMPLEMENTATION
      */
 
-    /* First, create a Broadcast of the snp values that are already in the model so that their values
-     *   will be available to all of the nodes (we know that they will all need copies of these)
-
-     * Since a broadcast cannot be updated, these need to be recreated at the beginning of each iteration
-     *   as the SNPs included in the models change
-     */
-    val addedPrevValMap = collections.getAddedPrev.toVector.map(name => {
-                            Tuple2(name,
-                                   /* Although lookup returns a Collection, in case the key is found on multiple
-                                    *   partitions, we know that there is only one. We just grab it with head
-                                    */
-                                   snpDataRDD.lookup(name).head
-                                  )
-                          }).toMap
-                          
-    val addedPrevBroadcast = spark.broadcast(addedPrevValMap)
-
-    /*
+    /*==================================================================================================================
      *  Step 1: find the best regression for those SNPs still under consideration
-     */
+     =================================================================================================================*/
 
     // Map generates all of the regression outputs, and reduce finds the best one
-    val mappedValues: rdd.RDD[Option[OLSRegression]] = snpDataRDD.map(mapFunction(_, addedPrevBroadcast))
+    val mappedValues: rdd.RDD[Option[OLSRegression]] = snpDataRDD.map(mapFunction)
     val bestRegression: OLSRegression = reduceFunction(mappedValues)
 
     bestRegression.printSummary()
-    collections.getSkipped.foreach(x => print(x + ", "))
 
     // If the p-value of the newest term does not meet the threshold, return the prev_best_model
     if (getNewestTermsPValue(bestRegression) >= threshold) {
       if (prev_best_model != null) { return prev_best_model }
-      else {
-        addedPrevBroadcast.destroy()
-        throw new Exception("No terms could be added to the model at a cutoff of " + threshold)
-      }
+      else { throw new Exception("No terms could be added to the model at a cutoff of " + threshold) }
     }
     else {
-      val new_collections = collections.copy()
-
-      // Now that the regressions for this round have been completed, return any entries in the skipped category to the
-      //   not added category
-      new_collections.getSkipped.foreach( x => new_collections.moveFromSkipped2NotAdded(x) )
+      /*
+       * Now that the regressions for this round have been completed, return any entries in the skipped category to the
+       *   not added category
+       */
+      collections.getSkipped.foreach( x => collections.moveFromSkipped2NotAdded(x) )
 
       // Remove the newest term from the not_added category and put it in the added_prev category
-      new_collections.moveFromNotAdded2AddedPrev(snpName = getNewestTermsName(bestRegression),
-                                                 snpValues = getNewestTermsValues(bestRegression)
-                                                 )
-
-      /*
+      collections.moveFromNotAdded2AddedPrev(snpName = getNewestTermsName(bestRegression),
+                                             snpValues = getNewestTermsValues(bestRegression)
+                                             )
+      /*================================================================================================================
        * Step 2: Check to make sure none of the previously added terms are no longer significant
-       * 				 If they are, remove them from consideration in the next round (put them in skipped) and
+       * 				 If they are, remove them from consideration in the next round (put them in the skipped category) and
        *         take them out of the model
-       */
-      
-      val namePValuePairs = bestRegression.xColumnNames.zip(bestRegression.pValues)
-      
-      namePValuePairs.foreach(pair => {
-        if (pair._2 >= threshold) {
-          // Remove this term from the prev_added collection, and move it to the skipped category
-          new_collections.moveFromAddedPrev2Skipped(pair._1)
-        }
-      })
-        
-      // Add the name to the entriesSkippedThisRound variable so that at the end, this can be removed
-          // from the BestRegression that is passed to the next iteration
-      val entriesSkippedThisRound = namePValuePairs.filter(_._2 >= threshold).map(_._1)
-      
-      if (new_collections.getNotAdded.isEmpty) {
+       ===============================================================================================================*/
+
+      val namePValuePairs: Array[(String, Double)] = bestRegression.xColumnNames.zip(bestRegression.pValues)
+
+      // Remove all terms that are no longer significant, and move them to the skipped category
+      namePValuePairs.foreach(pair => if (pair._2 >= threshold) collections.moveFromAddedPrev2Skipped(pair._1) )
+
+      if (collections.getNotAdded.isEmpty) {
         /*
-         * No more terms that could be added. Return the current best model, unless there are entries
+         * No more terms are under consideration. Return the current best model, unless there are entries
          * in the skipped category.
-         * 
-         * If this is the case, perform one last regression with the current add_prev collection in 
-         * the model. 
-         * 
-         * If something is in the skipped category at this point it was added during this iteration.
-         * and the "bestRegression" variable will still have that term included.
+         *
+         * If this is the case, perform one last regression with the current collections.add_prev terms in the model
+         *   (the items in the skipped category were skipped on this round, so we must create a final model without
+         *   them included)
          */
-        if (new_collections.getSkipped.isEmpty) {return bestRegression}
-        else {
-          
-          val newestXColName = bestRegression.xColumnNames.last
-          val otherXColNames = new_collections.getAddedPrev.filterNot(_ == newestXColName).toArray
-
-          // New x values: look up the previously added from the broadcast table, then include the values of
-          //   the latest term to be added
-          // val xVals = otherXColNames.map(addedPrevBroadcast.value(_)).toVector :+ bestRegression.lastXColumnsValues
-          val xVals: Array[BreezeVector[Double]] =
-            otherXColNames.map(addedPrevBroadcast.value(_)) :+ bestRegression.lastXColumnsValues
-
-          val yVals = broadcastPhenotypes.value(phenotypeName)
-
-          // We must convert to Scala Vector because BreezeVectors are not able to be flattened)
-          val flattenedXValues = flattenArrayOfBreezeVectors(xVals)
-          val xColNames = newestXColName +: otherXColNames
-          val numRows = yVals.length
-          val numCols = xColNames.length
-          val xValsMatrix: DenseMatrix[Double] = new DenseMatrix(numRows, numCols, flattenedXValues)
-          
-          addedPrevBroadcast.destroy()
-
-          return new OLSRegressionDense(xColNames, phenotypeName, xValsMatrix, yVals)
-        }
-      } else {
-        
+        if (collections.getSkipped.isEmpty) return bestRegression
+        else return rebuildModel()
+      }
+      else {
         /*
          * If any entries were skipped this round, recompute the regression without these terms,
          *  and then include the new best regression in the next iteration
          */
-        val newBestRegression = {
-          
-          if (entriesSkippedThisRound.length > 0) {
-            
-            val newestXColName = bestRegression.xColumnNames.last
-            val otherXColNames = new_collections.getAddedPrev.filterNot(_ == newestXColName).toArray
-          
-            val nameInSkipped: (String => Boolean) = entriesSkippedThisRound.contains(_)
-          
-            val significantXColNames = otherXColNames.filterNot(nameInSkipped(_))
-            // New x values: look up the previously added from the broadcast table, then include the values of
-            //   the latest term to be added
-            val xVals = significantXColNames.map(addedPrevBroadcast.value(_)) :+ bestRegression.lastXColumnsValues
+        val newBestReg: OLSRegression =  if (collections.getSkipped.nonEmpty) rebuildModel() else bestRegression
 
-            val yVals = broadcastPhenotypes.value(phenotypeName)
-
-            val flattenedXValues = flattenArrayOfBreezeVectors(xVals)
-            val xColNames = newestXColName +: significantXColNames
-            val numRows = yVals.length
-            val numCols = xColNames.length
-            val xValsMatrix: DenseMatrix[Double] = new DenseMatrix(numRows, numCols, flattenedXValues)
-            
-            new OLSRegressionDense(xColNames, phenotypeName, xValsMatrix, yVals)
-          }
-          else {
-            bestRegression
-          }
-        }
-        
-        addedPrevBroadcast.destroy() 
-        
-        performSteps(spark, snpDataRDD, broadcastPhenotypes, phenotypeName,
-                     new_collections, threshold, newBestRegression, iterations + 1
-                    )
+        /*==============================================================================================================
+         * Step 3: Make the recursive call with the updated information
+         =============================================================================================================*/
+        performSteps(spark, snpDataRDD, broadcastPheno, phenoName, collections, threshold, newBestReg, iterations + 1)
       }
     }
   }

--- a/SPAEML/src/main/scala/spaeml/StepCollections.scala
+++ b/SPAEML/src/main/scala/spaeml/StepCollections.scala
@@ -28,13 +28,15 @@ class StepCollections(not_added: mutable.HashSet[String],
   /*
       Direction of flow of SNP names in StepCollections
 
-        not_added ---> added_prev ---> skipped
+             +>-----> added_prev ---->-+
+            /                            \
+        not_added                       skipped
            ^                             /
             \   (after one iteration)   /
              +<-----<-----<-----<-----<+
  */
 
-  val addedPrevValues: mutable.HashMap[String, breeze.linalg.Vector[Double]] = new mutable.HashMap()
+  val addedPrevValues: mutable.HashMap[String, breeze.linalg.DenseVector[Double]] = new mutable.HashMap()
 
   def getNotAdded: mutable.HashSet[String] = not_added
   def getAddedPrev: mutable.HashSet[String] = added_prev
@@ -45,7 +47,7 @@ class StepCollections(not_added: mutable.HashSet[String],
     to.add(snpName)
   }
 
-  def moveFromNotAdded2AddedPrev(snpName: String, snpValues: breeze.linalg.Vector[Double]): Unit = {
+  def moveFromNotAdded2AddedPrev(snpName: String, snpValues: breeze.linalg.DenseVector[Double]): Unit = {
     moveFrom(not_added, added_prev, snpName)
     addedPrevValues.put(snpName, snpValues)
   }

--- a/SPAEML/src/main/scala/spaeml/StepCollections.scala
+++ b/SPAEML/src/main/scala/spaeml/StepCollections.scala
@@ -1,0 +1,60 @@
+package spaeml
+
+import scala.collection.mutable
+
+/**
+  * Keeps track of the state each SNP/SNP_combination is in
+  *
+  * When going through the model building process, each SNP/SNP_combination can be in one of three states:
+  *   not_added: has not yet been included in the model, still under consideration
+  *   added_prev: was added in a previous iteration, will be included in the model in addition to the current SNP being
+  *                 considered
+  *   skipped: was removed in the backward step of the last iteration; after being removed, SNPs are not considered for
+  *              one iteration
+  *
+  * Furthermore, during each step, we need to broadcast a table with the values for all of the SNPs in the added_prev
+  *   category. Because we do not want to look these up at the beginning of each iteration, it is useful to keep track
+  *   of them here, alongside the state of each SNP. We can also ensure that if a SNP is removed from the added_prev
+  *   category, its values are removed from the added_prev table as well
+  */
+class StepCollections(not_added: mutable.HashSet[String],
+                      added_prev: mutable.HashSet[String] = mutable.HashSet(),
+                      skipped: mutable.HashSet[String] = mutable.HashSet()) extends Serializable {
+
+  def copy(): StepCollections = {
+    new StepCollections(not_added, added_prev, skipped)
+  }
+
+  /*
+      Direction of flow of SNP names in StepCollections
+
+        not_added ---> added_prev ---> skipped
+           ^                             /
+            \   (after one iteration)   /
+             +<-----<-----<-----<-----<+
+ */
+
+  val addedPrevValues: mutable.HashMap[String, breeze.linalg.Vector[Double]] = new mutable.HashMap()
+
+  def getNotAdded: mutable.HashSet[String] = not_added
+  def getAddedPrev: mutable.HashSet[String] = added_prev
+  def getSkipped: mutable.HashSet[String] = skipped
+
+  private def moveFrom(from: mutable.HashSet[String], to: mutable.HashSet[String], snpName: String): Unit = {
+    from.remove(snpName)
+    to.add(snpName)
+  }
+
+  def moveFromNotAdded2AddedPrev(snpName: String, snpValues: breeze.linalg.Vector[Double]): Unit = {
+    moveFrom(not_added, added_prev, snpName)
+    addedPrevValues.put(snpName, snpValues)
+  }
+
+  def moveFromAddedPrev2Skipped(snpName: String): Unit = {
+    moveFrom(added_prev, skipped, snpName)
+    addedPrevValues.remove(snpName)
+  }
+
+  def moveFromSkipped2NotAdded(snpName: String): Unit = moveFrom(skipped, not_added, snpName)
+
+}

--- a/SPAEML/src/test/scala/spaeml/SPAEMLDenseTest.scala
+++ b/SPAEML/src/test/scala/spaeml/SPAEMLDenseTest.scala
@@ -112,7 +112,7 @@ class SPAEMLDenseTest {
     //   skipped term) is returned
     val not_added_init = HashSet() ++ Vector("x1")
     val added_prev_init = HashSet() ++ Vector("x3")
-    val initial_collection = StepCollections(not_added = not_added_init, added_prev = added_prev_init)
+    val initial_collection = new StepCollections(not_added = not_added_init, added_prev = added_prev_init)
     
     val reg = SPAEMLDense.performSteps(spark.sparkContext,
                                         stepDataRDD,


### PR DESCRIPTION
# Restructured StepCollections class and changed how SNP state is updated

Before, StepCollections was a case class with not_added, added_prev, and
  skipped categories for each SNP. Changed things so that now the values
  that go with all of the SNPs in the added category will be stored in
  a hash map within this class

Also added moving functions and added getters, so the only way to change
  the state data is to go through the methods